### PR TITLE
feat(install): add install instructions, fix release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,8 +3,8 @@ name: Build
 on:
   push:
     branches: '**'
-    release:
-      types: [created]
+  release:
+    types: [created]
 
 permissions:
   contents: write

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ PLATFORMS ?= darwin/amd64 darwin/arm64 windows/amd64 linux/amd64 linux/arm64 lin
 RELEASE_UPLOAD_URL ?=
 
 build:
-	for plt in $(PLATFORMS); \
+	@for plt in $(PLATFORMS); \
 	do \
 		os=$${plt%%/*}; \
 		arv=$${plt#*/}; \
@@ -21,7 +21,7 @@ build:
 			-o dist/image-prune-$${os}-$${arch} \
 			-ldflags=$(LINKER_FLAGS) \
 			-tags exclude_graphdriver_btrfs \
-			./cmd; \
+			.; \
 	done \
 
 lint-dependencies:
@@ -31,7 +31,7 @@ lint:
 	@golangci-lint run
 
 release:
-	bash ci/release.sh "$(RELEASE_UPLOAD_URL)" "$(PLATFORMS)"
+	@bash ci/release.sh "$(RELEASE_UPLOAD_URL)" "$(PLATFORMS)"
 
 test-setup:
-	bash ci/test/setup.sh
+	@bash ci/test/setup.sh

--- a/README.md
+++ b/README.md
@@ -8,12 +8,57 @@ A command-line interface for pruning container images in bulk from a container i
 >
 > The `image-prune` CLI is built on the same foundational library as `skopeo`, and thus is impacted by this issue as well.  Please use this tool at your own risk.
 
+![image-prune prune --before-version](./doc/img/prune-before-version-tag.gif)
+
+For more demos, see [doc/demos.md](./doc/demos.md)
+
 ## Install
 
-TODO: Create a release of the CLI
+### Pre-compiled release
 
-## Demo
+For each release of `image-prune`, we publish pre-compiled builds of the `image-prune` CLI.
 
-> For more demos, see [doc/demos.md](./doc/demos.md)
+#### Install script
 
-![image-prune prune --before-version](./doc/img/prune-before-version-tag.gif)
+For convenience, you may use our [install script](install.sh) to download and install the latest pre-compiled `image-prune` CLI.
+```
+Usage:
+  <sh | bash> install.sh <version> [os] [arch]
+
+Example:
+  sh install.sh v1.0.0-alpha.1 linux amd64
+```
+
+This assumes
+- You are running on a unix-like system supporting `sh` or `bash`
+- The `/usr/local/bin` subdirectory exists, and is on your `PATH`
+- You have `curl` and `jq` installed
+- You have a GitHub personal access token which expires no more than one year from now
+- (Optional) You have `go` installed, in which case you may omit the `[os]` and `[arch]` optional positional args above
+
+#### Manual
+
+Each of our releases contain pre-compiled binaries which you may install manually if the install script is not suitable for your use case
+- https://github.com/IBM/image-prune/releases
+
+### Build from source
+
+#### Using `go install`
+
+If you have `go` installed, you may also install the CLI using
+```
+GOBIN="/usr/local/bin" go install github.com/IBM/image-prune/cmd@v1.0.0-alpha.1
+```
+
+> [!NOTE]
+> This will build the `image-prune` CLI from source on your machine, and may lead to unexpected results when using the `image-prune version` subcommand.
+
+#### Using `go build`
+
+Clone this repository on the tag corresponding to the version you would like to install.  The latest is `v1.0.0-alpha.1`.  Run
+```bash
+YOUR_OS="<your-os>"
+YOUR_ARCH="<your-arch>"
+make build PLATFORMS="$YOUR_OS/$YOUR_ARCH"
+mv ./dist/image-prune-${YOUR_OS}-${YOUR_ARCH} /usr/local/bin/image-prune
+```

--- a/cmd/list_tags.go
+++ b/cmd/list_tags.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"context"

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"bufio"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"context"
@@ -8,7 +8,6 @@ import (
 
 	commonFlag "github.com/containers/common/pkg/flag"
 	"github.com/containers/image/v5/types"
-	"github.com/containers/storage/pkg/reexec"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -43,7 +42,7 @@ func requireSubcommand(cmd *cobra.Command, args []string) error {
 }
 
 // createApp returns a cobra.Command, and the underlying globalOptions object, to be run or tested.
-func createApp() (*cobra.Command, *globalOptions) {
+func CreateApp() (*cobra.Command, *globalOptions) {
 	opts := globalOptions{}
 
 	rootCommand := &cobra.Command{
@@ -91,20 +90,6 @@ func (opts *globalOptions) before(cmd *cobra.Command, args []string) error {
 		logrus.Warn("'--tls-verify' is deprecated, please set this on the specific subcommand")
 	}
 	return nil
-}
-
-func main() {
-	if reexec.Init() {
-		return
-	}
-	rootCmd, _ := createApp()
-	if err := rootCmd.Execute(); err != nil {
-		if isNotFoundImageError(err) {
-			logrus.StandardLogger().Log(logrus.FatalLevel, err)
-			logrus.Exit(2)
-		}
-		logrus.Fatal(err)
-	}
 }
 
 // commandTimeoutContext returns a context.Context and a cancellation callback based on opts.

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"context"
@@ -280,11 +280,11 @@ func adjustUsage(c *cobra.Command) {
 	c.DisableFlagsInUseLine = true
 }
 
-// isNotFoundImageError heuristically attempts to determine whether an error
+// IsNotFoundImageError heuristically attempts to determine whether an error
 // is saying the remote source couldn't find the image (as opposed to an
 // authentication error, an I/O error etc.)
 // TODO drive this into containers/image properly
-func isNotFoundImageError(err error) bool {
+func IsNotFoundImageError(err error) bool {
 	var layoutImageNotFoundError ocilayout.ImageNotFoundError
 	var archiveImageNotFoundError ociarchive.ImageNotFoundError
 	return isDockerManifestUnknownError(err) ||

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	// Standard library modules

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,116 @@
+# User input
+VERSION=${1:-"v1.0.0-alpha.1"}
+OPERATING_SYSTEM=${2:-"$(go env GOOS 2>/dev/null)"}
+ARCHITECTURE=${3:-"$(go env GOARCH 2>/dev/null)"}
+
+# Display install script usage
+function display_usage() {
+    echo "
+Usage:
+  <sh | bash> install.sh <version> [os] [arch]
+
+Example:
+  sh install.sh v1.0.0-alpha.1 linux amd64
+"
+}
+
+# Fetch the release assets URL from the Github release
+function get_release_assets_url() {
+    local assets_url=$(
+        curl -sL \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/IBM/image-prune/releases/tags/${VERSION} \
+            | jq -r .assets_url
+    )
+    echo "$assets_url"
+}
+
+# Fetch the release assets using the GitHub release assets URL
+function list_release_assets() {
+    local assets_url=$1
+    local assets=$(
+        curl -sL \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "$assets_url"
+    )
+    echo "$assets"
+}
+
+# Fetch the release asset matching the given OS and architecture
+function get_platform_release_asset() {
+    local assets=$1
+    echo "$assets" | jq -c '.[]' | while read i; do
+        asset_name=$(echo $i | jq -r '.name')
+        asset_url=$(echo $i | jq -r '.url')
+        if [[ "$asset_name" == *"${OPERATING_SYSTEM}-${ARCHITECTURE}" ]]; then
+            asset_path="$(pwd)/image-prune"
+            echo "Downloading $asset_name to temporary path $asset_path"
+            curl -sL \
+                -H "Accept: application/octet-stream" \
+                -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                -o "$(pwd)/image-prune" \
+                "${asset_url}"
+        fi
+    done
+}
+
+# Move the downloaded release asset onto the PATH and make executable
+function add_asset_to_path() {
+    local asset_path=$1
+    local new_asset_path="/usr/local/bin/image-prune"
+    echo "Moving onto PATH $asset_path -> $new_asset_path"
+    mv "$asset_path" "$new_asset_path"
+    chmod +x "$new_asset_path"
+}
+
+# Ensure required env vars are set
+if [[ -z "$OPERATING_SYSTEM" ]]; then
+    echo "
+[ERROR] No os given
+
+Hint: Set environment variable: OPERATING_SYSTEM
+"
+    display_usage
+    exit 1
+fi
+if [[ -z "$ARCHITECTURE" ]]; then
+    echo "
+[ERROR] No arch given
+
+Hint: Set environment variable: ARCHITECTURE
+"
+    display_usage
+    exit 1
+fi
+if [[ -z "$GITHUB_TOKEN" ]]; then
+    echo "
+[ERROR] No github token given
+
+Hint: Set environment variable: GITHUB_TOKEN
+"
+fi
+
+# Get the release corresponding to the given version
+release_assets_url=$(get_release_assets_url)
+if [[ "$release_assets_url" == "null" ]]; then
+    echo "[ERROR] image-prune version ${VERSION} does not exist"
+    exit 1
+fi
+
+# List the release assets corresponding to the given version
+release_assets=$(list_release_assets "$release_assets_url")
+
+# Get the release asset matching the given os/arch
+get_platform_release_asset "$release_assets"
+asset_path="$(pwd)/image-prune"
+if [ ! -f "$asset_path" ]; then
+    echo "[ERROR] image-prune does not support platform ${OPERATING_SYSTEM}/${ARCHITECTURE}"
+    exit 1
+fi
+
+# Add the asset to the path, make executable
+add_asset_to_path "$asset_path"

--- a/main.go
+++ b/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"github.com/IBM/image-prune/cmd"
+
+	"github.com/containers/storage/pkg/reexec"
+	"github.com/sirupsen/logrus"
+)
+
+func main() {
+	if reexec.Init() {
+		return
+	}
+	rootCmd, _ := cmd.CreateApp()
+	if err := rootCmd.Execute(); err != nil {
+		if cmd.IsNotFoundImageError(err) {
+			logrus.StandardLogger().Log(logrus.FatalLevel, err)
+			logrus.Exit(2)
+		}
+		logrus.Fatal(err)
+	}
+}


### PR DESCRIPTION
Adds an install script, as well as other documented install methods.  Updates the package structure to enable using `go install`.  Updates the Make recipe accordingly.  Attempts to fix the build workflow to trigger on release.