### PR TITLE
fix(mod): format, tidy, and vet go module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ VERSION := v0.1.0
 DATE := $(shell date)
 COMMIT := $(shell git rev-parse --short HEAD)
 
-VERSION_LINKER_FLAG := 'main.ImagePruneVersion=$(VERSION)'
-DATE_LINKER_FLAG := 'main.ImagePruneBuildDate=$(DATE)'
-COMMIT_LINKER_FLAG := 'main.ImagePruneCommit=$(COMMIT)'
+VERSION_LINKER_FLAG := 'github.com/IBM/image-prune/cmd.ImagePruneVersion=$(VERSION)'
+DATE_LINKER_FLAG := 'github.com/IBM/image-prune/cmd.ImagePruneBuildDate=$(DATE)'
+COMMIT_LINKER_FLAG := 'github.com/IBM/image-prune/cmd.ImagePruneCommit=$(COMMIT)'
 LINKER_FLAGS := "-X $(VERSION_LINKER_FLAG) -X $(DATE_LINKER_FLAG) -X $(COMMIT_LINKER_FLAG)"
 
 PLATFORMS ?= darwin/amd64 darwin/arm64 windows/amd64 linux/amd64 linux/arm64 linux/ppc64le linux/s390x

--- a/cmd/list_tags.go
+++ b/cmd/list_tags.go
@@ -82,7 +82,7 @@ type tagsOptions struct {
 }
 
 var transportHandlers = map[string]func(ctx context.Context, sys *types.SystemContext, opts *tagsOptions, userInput string) (repositoryName string, tagListing []string, err error){
-	docker.Transport.Name():  listDockerRepoTags,
+	docker.Transport.Name(): listDockerRepoTags,
 }
 
 // supportedTransports returns all the supported transports

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -232,7 +232,7 @@ func getManifestListSizeMaps(ctx context.Context, sys *types.SystemContext, repo
 	// Initialize the size maps
 	configSizeMap = make(map[string]int64)
 	layerSizeMap = make(map[string]int64)
-	
+
 	// Convert the raw manifest to a slice of v2 descriptors
 	manifestList, err := manifest.ListFromBlob(rawManifest, mimeType)
 	if err != nil {
@@ -613,7 +613,7 @@ func pruneDockerTags(ctx context.Context, sys *types.SystemContext, opts *pruneO
 		return fmt.Errorf("error parsing image reference: %w", err)
 	}
 	repositoryName := imgRef.DockerReference().Name()
-	
+
 	// Get the filtered docker tags for the given repository
 	filteredTags, err := getFilteredDockerTags(ctx, sys, opts.intoTagsOptions(), repositoryName)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,10 @@ require (
 	github.com/containers/image/v5 v5.36.0
 	github.com/containers/storage v1.59.0
 	github.com/docker/distribution v2.8.3+incompatible
-	github.com/opencontainers/image-spec v1.1.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.7
 	golang.org/x/mod v0.26.0
-	golang.org/x/term v0.33.0
 )
 
 require (
@@ -56,6 +54,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opencontainers/runtime-spec v1.2.1 // indirect
 	github.com/opencontainers/selinux v1.12.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -273,8 +273,6 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
 golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
-golang.org/x/term v0.33.0 h1:NuFncQrRcaRvVmgRkvM3j/F00gWIAlcmlB8ACEKmGIg=
-golang.org/x/term v0.33.0/go.mod h1:s18+ql9tYWp1IfpV9DmCtQDDSRBUjKaw9M1eAv5UeF0=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.27.0 h1:4fGWRpyh641NLlecmyl4LOe6yDdfaYNrGb2zdfo4JV4=


### PR DESCRIPTION
Formats, tidies, and vets the go module.  Attempting to fix persistent issues installing via `go install` by creating a new `v1.0.0-alpha.2` release.