### PR TITLE
chore(version): update docs for alpha.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Usage:
   <sh | bash> install.sh <version> [os] [arch]
 
 Example:
-  sh install.sh v1.0.0-alpha.1 linux amd64
+  sh install.sh v1.0.0-alpha.2 linux amd64
 ```
 
 This assumes
@@ -53,7 +53,7 @@ Each of our releases contain pre-compiled binaries which you may install manuall
 
 If you have `go` installed, you may also install the CLI using
 ```
-GOBIN="/usr/local/bin" go install github.com/IBM/image-prune@v1.0.0-alpha.1
+GOBIN="/usr/local/bin" go install github.com/IBM/image-prune@v1.0.0-alpha.2
 ```
 
 > [!NOTE]
@@ -61,7 +61,7 @@ GOBIN="/usr/local/bin" go install github.com/IBM/image-prune@v1.0.0-alpha.1
 
 #### Using `go build`
 
-Clone this repository on the tag corresponding to the version you would like to install.  The latest is `v1.0.0-alpha.1`.  Run
+Clone this repository on the tag corresponding to the version you would like to install.  The latest is `v1.0.0-alpha.2`.  Run
 ```bash
 YOUR_OS="<your-os>"
 YOUR_ARCH="<your-arch>"

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 # User input
-VERSION=${1:-"v1.0.0-alpha.1"}
+VERSION=${1:-"v1.0.0-alpha.2"}
 OPERATING_SYSTEM=${2:-"$(go env GOOS 2>/dev/null)"}
 ARCHITECTURE=${3:-"$(go env GOARCH 2>/dev/null)"}
 
@@ -10,7 +10,7 @@ Usage:
   <sh | bash> install.sh <version> [os] [arch]
 
 Example:
-  sh install.sh v1.0.0-alpha.1 linux amd64
+  sh install.sh v1.0.0-alpha.2 linux amd64
 "
 }
 


### PR DESCRIPTION
Retroactively updates the main branch docs & install script to install the alpha.2 release by default.